### PR TITLE
fix: handle existing JAVA_HOME

### DIFF
--- a/Factories/ProcessFactory.cs
+++ b/Factories/ProcessFactory.cs
@@ -62,7 +62,8 @@ namespace minecraft_windows_service_wrapper.Factories
             // Set JAVA_HOME environment variable if specified
             if (!string.IsNullOrWhiteSpace(options.JavaHome))
             {
-                processStartInfo.Environment.Add("JAVA_HOME", javaHome);
+                // Use indexer assignment instead of Add to avoid exceptions when JAVA_HOME already exists
+                processStartInfo.Environment["JAVA_HOME"] = javaHome;
             }
 
             // Build arguments using strategies

--- a/MinecraftServer.Tests/ProcessFactoryTests.cs
+++ b/MinecraftServer.Tests/ProcessFactoryTests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using minecraft_windows_service_wrapper.Factories;
+using minecraft_windows_service_wrapper.Options;
+using minecraft_windows_service_wrapper.Services;
+using minecraft_windows_service_wrapper.Strategies.Java;
+using minecraft_windows_service_wrapper.Strategies.Minecraft;
+
+namespace MinecraftServer.Tests
+{
+    public class ProcessFactoryTests
+    {
+        [Fact]
+        public async Task CreateMinecraftServerProcessAsync_OverridesExistingJavaHome()
+        {
+            // Arrange
+            var mockLogger = new Mock<ILogger<ProcessFactory>>();
+            var mockJavaVersionService = new Mock<IJavaVersionService>();
+            var mockJavaStrategyFactory = new Mock<IJavaVersionStrategyFactory>();
+            var mockMinecraftStrategyFactory = new Mock<IMinecraftVersionStrategyFactory>();
+
+            mockJavaVersionService.Setup(s => s.GetJavaHomeAsync())
+                .ReturnsAsync("/existing/java");
+            mockJavaVersionService.Setup(s => s.GetJavaExecutablePathAsync(It.IsAny<string>()))
+                .ReturnsAsync("/path/to/java");
+            mockJavaVersionService.Setup(s => s.GetJavaVersionAsync(It.IsAny<string>()))
+                .ReturnsAsync(17);
+
+            var javaStrategy = new Mock<IJavaVersionStrategy>();
+            javaStrategy.Setup(s => s.GetMemoryArguments(It.IsAny<MinecraftServerOptions>()))
+                .Returns(Array.Empty<string>());
+            javaStrategy.Setup(s => s.GetGarbageCollectionArguments())
+                .Returns(Array.Empty<string>());
+            javaStrategy.Setup(s => s.GetAdditionalArguments())
+                .Returns(Array.Empty<string>());
+            mockJavaStrategyFactory.Setup(s => s.GetStrategy(It.IsAny<int>()))
+                .Returns(javaStrategy.Object);
+
+            var minecraftStrategy = new Mock<IMinecraftVersionStrategy>();
+            minecraftStrategy.Setup(s => s.GetMinecraftArguments(It.IsAny<MinecraftServerOptions>()))
+                .Returns(Array.Empty<string>());
+            mockMinecraftStrategyFactory.Setup(s => s.GetStrategy(It.IsAny<Version>()))
+                .Returns(minecraftStrategy.Object);
+
+            var factory = new ProcessFactory(
+                mockLogger.Object,
+                mockJavaVersionService.Object,
+                mockJavaStrategyFactory.Object,
+                mockMinecraftStrategyFactory.Object);
+
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+            var jarPath = Path.Combine(tempDir, "server.jar");
+            File.WriteAllText(jarPath, string.Empty);
+
+            var options = new MinecraftServerOptions
+            {
+                ServerDirectory = tempDir,
+                JarFileName = "server.jar",
+                JavaHome = "/custom/java",
+                MinecraftVersion = new Version(1, 16, 5)
+            };
+
+            Environment.SetEnvironmentVariable("JAVA_HOME", "/preexisting");
+
+            try
+            {
+                // Act
+                var psi = await factory.CreateMinecraftServerProcessAsync(options);
+
+                // Assert
+                Assert.Equal("/custom/java", psi.Environment["JAVA_HOME"]);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("JAVA_HOME", null);
+                File.Delete(jarPath);
+                Directory.Delete(tempDir);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- avoid exception when JAVA_HOME already defined
- test ProcessFactory replaces existing JAVA_HOME

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6897c9825990832eac98bd12f716641a