### PR TITLE
Skip port flag when port is unspecified

### DIFF
--- a/MinecraftServer.Tests/ArgumentsBuilderServiceTests.cs
+++ b/MinecraftServer.Tests/ArgumentsBuilderServiceTests.cs
@@ -70,6 +70,27 @@ namespace MinecraftServer.Tests
         }
 
         [Theory]
+        [InlineData(12)]
+        [InlineData(16)]
+        public void BuildMinecraftArguments_WhenPortIsNegative_OmitsPortArgument(int minorVersion)
+        {
+            // Arrange
+            var options = new MinecraftServerOptions
+            {
+                MinecraftVersion = new Version(1, minorVersion, 0),
+                Port = -1
+            };
+
+            // Act
+            var result = _service.BuildMinecraftArguments(options);
+            var args = result.ToList();
+
+            // Assert
+            Assert.DoesNotContain("--port", args);
+            Assert.DoesNotContain("-1", args);
+        }
+
+        [Theory]
         [InlineData(8)]
         [InlineData(11)]
         [InlineData(17)]

--- a/MinecraftServer.Tests/MinecraftVersionStrategyTests.cs
+++ b/MinecraftServer.Tests/MinecraftVersionStrategyTests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Linq;
+using Xunit;
+using minecraft_windows_service_wrapper.Options;
+using minecraft_windows_service_wrapper.Strategies.Minecraft;
+
+namespace MinecraftServer.Tests
+{
+    public class MinecraftVersionStrategyTests
+    {
+        [Fact]
+        public void Minecraft12Strategy_SkipsPortWhenNegative()
+        {
+            var strategy = new Minecraft12Strategy();
+            var options = new MinecraftServerOptions
+            {
+                MinecraftVersion = new Version(1, 12),
+                Port = -1
+            };
+
+            var args = strategy.GetMinecraftArguments(options).ToList();
+            Assert.Contains("nogui", args);
+            Assert.DoesNotContain("--port", args);
+        }
+
+        [Fact]
+        public void ModernMinecraftStrategy_SkipsPortWhenNegative()
+        {
+            var strategy = new ModernMinecraftStrategy();
+            var options = new MinecraftServerOptions
+            {
+                MinecraftVersion = new Version(1, 16),
+                Port = -1
+            };
+
+            var args = strategy.GetMinecraftArguments(options).ToList();
+            Assert.Contains("--nogui", args);
+            Assert.DoesNotContain("--port", args);
+        }
+    }
+}

--- a/Services/ArgumentsBuilderService.cs
+++ b/Services/ArgumentsBuilderService.cs
@@ -46,18 +46,24 @@ namespace minecraft_windows_service_wrapper.Services
 
             var args = new List<string>();
 
-            // Add GUI and port arguments based on Minecraft version
+            // Add GUI and optional port arguments based on Minecraft version
             if (options.MinecraftVersion.Minor == 12)
             {
                 args.Add("nogui");
-                args.Add("--port");
-                args.Add(options.Port.ToString());
+                if (options.Port >= 0)
+                {
+                    args.Add("--port");
+                    args.Add(options.Port.ToString());
+                }
             }
             else if (options.MinecraftVersion.Minor >= 16)
             {
                 args.Add("--nogui");
-                args.Add("--port");
-                args.Add(options.Port.ToString());
+                if (options.Port >= 0)
+                {
+                    args.Add("--port");
+                    args.Add(options.Port.ToString());
+                }
             }
             else
             {

--- a/Strategies/Minecraft/Minecraft12Strategy.cs
+++ b/Strategies/Minecraft/Minecraft12Strategy.cs
@@ -20,10 +20,13 @@ namespace minecraft_windows_service_wrapper.Strategies.Minecraft
 
             // Minecraft 1.12 uses 'nogui' without dashes
             yield return "nogui";
-            yield return "--port";
-            
-            // Port handling: -1 means use default (25565)
-            yield return options.Port.ToString();
+
+            // Port handling: only specify when non-negative
+            if (options.Port >= 0)
+            {
+                yield return "--port";
+                yield return options.Port.ToString();
+            }
         }
     }
 }

--- a/Strategies/Minecraft/ModernMinecraftStrategy.cs
+++ b/Strategies/Minecraft/ModernMinecraftStrategy.cs
@@ -20,10 +20,13 @@ namespace minecraft_windows_service_wrapper.Strategies.Minecraft
 
             // Minecraft 1.16+ uses '--nogui' with dashes
             yield return "--nogui";
-            yield return "--port";
-            
-            // Port handling: -1 means use default (25565)
-            yield return options.Port.ToString();
+
+            // Port handling: only specify when non-negative
+            if (options.Port >= 0)
+            {
+                yield return "--port";
+                yield return options.Port.ToString();
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Only append --port when `options.Port >= 0` in ArgumentsBuilderService and Minecraft strategies
- Cover negative port cases with new tests

## Testing
- `dotnet test -p:EnableWindowsTargeting=true` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json)*

------
https://chatgpt.com/codex/tasks/task_e_68982fd3866c832e9ff5fcefbe1a68d2