### PR TITLE
Respect configured memory settings for Java arguments

### DIFF
--- a/MinecraftServer.Tests/ArgumentsBuilderServiceTests.cs
+++ b/MinecraftServer.Tests/ArgumentsBuilderServiceTests.cs
@@ -24,7 +24,9 @@ namespace MinecraftServer.Tests
                 ServerDirectory = @"C:\test\server",
                 MinecraftVersion = new Version(1, 16, 5),
                 Port = 25565,
-                JarFileName = "server.jar"
+                JarFileName = "server.jar",
+                MaxMemoryMB = 4096,
+                MinMemoryMB = 1024
             };
         }
 
@@ -43,7 +45,8 @@ namespace MinecraftServer.Tests
             var args = result.ToList();
 
             // Assert
-            Assert.Contains("-Xmx8G", args);
+            Assert.Contains("-Xmx4096M", args);
+            Assert.Contains("-Xms1024M", args);
             Assert.Contains("-jar", args);
             Assert.Contains(serverJarPath, args);
             Assert.True(args.Count > 5);

--- a/Services/ArgumentsBuilderService.cs
+++ b/Services/ArgumentsBuilderService.cs
@@ -26,7 +26,7 @@ namespace minecraft_windows_service_wrapper.Services
             var args = new List<string>();
 
             // Memory settings
-            args.AddRange(GetMemoryArguments(javaVersion));
+            args.AddRange(GetMemoryArguments(options));
 
             // Garbage collection and performance arguments
             args.AddRange(GetGarbageCollectionArguments(javaVersion));
@@ -76,14 +76,13 @@ namespace minecraft_windows_service_wrapper.Services
             return javaArgs.Concat(minecraftArgs);
         }
 
-        private IEnumerable<string> GetMemoryArguments(int javaVersion)
+        private IEnumerable<string> GetMemoryArguments(MinecraftServerOptions options)
         {
-            return javaVersion switch
-            {
-                8 => new[] { "-Xmx8G", "-Xms3G" }, // Pixelmon recommends minimum 3G
-                11 or 17 or 21 => new[] { "-Xmx8G", "-Xms2G" },
-                _ => throw new NotSupportedException($"Java version {javaVersion} is not supported")
-            };
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
+
+            yield return $"-Xmx{options.MaxMemoryMB}M";
+            yield return $"-Xms{options.MinMemoryMB}M";
         }
 
         private IEnumerable<string> GetGarbageCollectionArguments(int javaVersion)


### PR DESCRIPTION
## Summary
- Derive Java memory flags from `MinecraftServerOptions` so configured min/max values are used.
- Test Java arguments builder to ensure `-Xmx` and `-Xms` match configured memory settings.

## Testing
- `dotnet test -p:EnableWindowsTargeting=true` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json)*

------
https://chatgpt.com/codex/tasks/task_e_68982fd1c0bc832e9cae19ff31b4ba47