### PR TITLE
Check process exit codes and log output

### DIFF
--- a/Gui/MainForm.cs
+++ b/Gui/MainForm.cs
@@ -366,9 +366,15 @@ namespace minecraft_windows_service_wrapper
                     try
                     {
                         await process.WaitForExitAsync(cts.Token);
-                        
+
                         var output = await process.StandardOutput.ReadToEndAsync();
                         var error = await process.StandardError.ReadToEndAsync();
+
+                        if (process.ExitCode != 0)
+                        {
+                            Debug.WriteLine($"Version detection failed with exit code {process.ExitCode}\nOutput: {output}\nError: {error}");
+                            return null;
+                        }
 
                         return ExtractMinecraftVersion(output + " " + error);
                     }

--- a/MinecraftServer.Tests/WindowsServiceManagerTests.cs
+++ b/MinecraftServer.Tests/WindowsServiceManagerTests.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Diagnostics;
+using Moq;
+using Xunit;
+using minecraft_windows_service_wrapper.Services;
+
+namespace MinecraftServer.Tests
+{
+    public class WindowsServiceManagerTests
+    {
+        [Fact]
+        public void Install_Success_DoesNotThrow()
+        {
+            var mockRunner = new Mock<IProcessRunner>();
+            mockRunner.Setup(r => r.Run(It.IsAny<ProcessStartInfo>()))
+                .Returns(new ProcessResult { ExitCode = 0, StandardOutput = "ok" });
+
+            WindowsServiceManager.Install("svc", "path", mockRunner.Object);
+        }
+
+        [Fact]
+        public void Install_Failure_Throws()
+        {
+            var mockRunner = new Mock<IProcessRunner>();
+            mockRunner.Setup(r => r.Run(It.IsAny<ProcessStartInfo>()))
+                .Returns(new ProcessResult { ExitCode = 1, StandardError = "error" });
+
+            Assert.Throws<InvalidOperationException>(() =>
+                WindowsServiceManager.Install("svc", "path", mockRunner.Object));
+        }
+
+        [Fact]
+        public void Remove_Success_DoesNotThrow()
+        {
+            var mockRunner = new Mock<IProcessRunner>();
+            mockRunner.Setup(r => r.Run(It.IsAny<ProcessStartInfo>()))
+                .Returns(new ProcessResult { ExitCode = 0 });
+
+            WindowsServiceManager.Remove("svc", mockRunner.Object);
+        }
+
+        [Fact]
+        public void Remove_Failure_Throws()
+        {
+            var mockRunner = new Mock<IProcessRunner>();
+            mockRunner.Setup(r => r.Run(It.IsAny<ProcessStartInfo>()))
+                .Returns(new ProcessResult { ExitCode = 2, StandardError = "not found" });
+
+            Assert.Throws<InvalidOperationException>(() =>
+                WindowsServiceManager.Remove("svc", mockRunner.Object));
+        }
+    }
+}

--- a/Services/IProcessRunner.cs
+++ b/Services/IProcessRunner.cs
@@ -1,0 +1,16 @@
+using System.Diagnostics;
+
+namespace minecraft_windows_service_wrapper.Services
+{
+    public interface IProcessRunner
+    {
+        ProcessResult Run(ProcessStartInfo startInfo);
+    }
+
+    public class ProcessResult
+    {
+        public int ExitCode { get; set; }
+        public string StandardOutput { get; set; } = string.Empty;
+        public string StandardError { get; set; } = string.Empty;
+    }
+}

--- a/Services/ProcessRunner.cs
+++ b/Services/ProcessRunner.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Diagnostics;
+
+namespace minecraft_windows_service_wrapper.Services
+{
+    public class ProcessRunner : IProcessRunner
+    {
+        public ProcessResult Run(ProcessStartInfo startInfo)
+        {
+            if (startInfo == null)
+                throw new ArgumentNullException(nameof(startInfo));
+
+            using var process = Process.Start(startInfo) ?? throw new InvalidOperationException("Failed to start process");
+            process.WaitForExit();
+
+            var output = startInfo.RedirectStandardOutput ? process.StandardOutput.ReadToEnd() : string.Empty;
+            var error = startInfo.RedirectStandardError ? process.StandardError.ReadToEnd() : string.Empty;
+
+            return new ProcessResult
+            {
+                ExitCode = process.ExitCode,
+                StandardOutput = output,
+                StandardError = error
+            };
+        }
+    }
+}

--- a/Services/WindowsServiceManager.cs
+++ b/Services/WindowsServiceManager.cs
@@ -1,10 +1,11 @@
+using System;
 using System.Diagnostics;
 
 namespace minecraft_windows_service_wrapper.Services
 {
     public static class WindowsServiceManager
     {
-        public static void Install(string serviceName, string exePath)
+        public static void Install(string serviceName, string exePath, IProcessRunner? processRunner = null)
         {
             var psi = new ProcessStartInfo("sc.exe", $"create \"{serviceName}\" binPath= \"{exePath}\"")
             {
@@ -12,11 +13,20 @@ namespace minecraft_windows_service_wrapper.Services
                 RedirectStandardOutput = true,
                 RedirectStandardError = true
             };
-            using var process = Process.Start(psi);
-            process?.WaitForExit();
+
+            processRunner ??= new ProcessRunner();
+            var result = processRunner.Run(psi);
+
+            if (!string.IsNullOrWhiteSpace(result.StandardOutput))
+                Console.WriteLine(result.StandardOutput);
+            if (!string.IsNullOrWhiteSpace(result.StandardError))
+                Console.Error.WriteLine(result.StandardError);
+
+            if (result.ExitCode != 0)
+                throw new InvalidOperationException($"Service installation failed with exit code {result.ExitCode}");
         }
 
-        public static void Remove(string serviceName)
+        public static void Remove(string serviceName, IProcessRunner? processRunner = null)
         {
             var psi = new ProcessStartInfo("sc.exe", $"delete \"{serviceName}\"")
             {
@@ -24,8 +34,17 @@ namespace minecraft_windows_service_wrapper.Services
                 RedirectStandardOutput = true,
                 RedirectStandardError = true
             };
-            using var process = Process.Start(psi);
-            process?.WaitForExit();
+
+            processRunner ??= new ProcessRunner();
+            var result = processRunner.Run(psi);
+
+            if (!string.IsNullOrWhiteSpace(result.StandardOutput))
+                Console.WriteLine(result.StandardOutput);
+            if (!string.IsNullOrWhiteSpace(result.StandardError))
+                Console.Error.WriteLine(result.StandardError);
+
+            if (result.ExitCode != 0)
+                throw new InvalidOperationException($"Service removal failed with exit code {result.ExitCode}");
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `IProcessRunner` abstraction and default `ProcessRunner` to capture stdout/stderr and exit codes
- update `WindowsServiceManager` to use the runner, log output, and throw on non-zero exit
- log version detection failures in `MainForm` and add tests simulating process success and failure

## Testing
- `dotnet test -p:EnableWindowsTargeting=true` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json)*

------
https://chatgpt.com/codex/tasks/task_e_68982fcdc254832e8436a0f6702d355a