### PR TITLE
Gracefully handle settings load failures

### DIFF
--- a/MinecraftServer.Tests/SettingsServiceTests.cs
+++ b/MinecraftServer.Tests/SettingsServiceTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IO;
+using minecraft_windows_service_wrapper.Options;
+using minecraft_windows_service_wrapper.Services;
+using Xunit;
+
+namespace MinecraftServer.Tests
+{
+    public class SettingsServiceTests
+    {
+        [Fact]
+        public void Load_WithMalformedJson_ReturnsDefaultOptions()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+            var previousAppData = Environment.GetEnvironmentVariable("APPDATA");
+            var previousXdgConfigHome = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+
+            try
+            {
+                Environment.SetEnvironmentVariable("APPDATA", tempDir);
+                Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", tempDir);
+
+                var configDir = Path.Combine(tempDir, "MinecraftServiceWrapper");
+                Directory.CreateDirectory(configDir);
+                var configPath = Path.Combine(configDir, "settings.json");
+                File.WriteAllText(configPath, "{ invalid json");
+
+                var options = SettingsService.Load();
+                var defaults = MinecraftServerOptions.CreateDefault();
+
+                Assert.Equal(defaults.Port, options.Port);
+                Assert.Equal(defaults.JarFileName, options.JarFileName);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("APPDATA", previousAppData);
+                Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", previousXdgConfigHome);
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+}

--- a/Services/SettingsService.cs
+++ b/Services/SettingsService.cs
@@ -21,8 +21,22 @@ namespace minecraft_windows_service_wrapper.Services
             if (!File.Exists(path))
                 return MinecraftServerOptions.CreateDefault();
 
-            var json = File.ReadAllText(path);
-            return JsonSerializer.Deserialize<MinecraftServerOptions>(json) ?? MinecraftServerOptions.CreateDefault();
+            try
+            {
+                var json = File.ReadAllText(path);
+                return JsonSerializer.Deserialize<MinecraftServerOptions>(json)
+                    ?? MinecraftServerOptions.CreateDefault();
+            }
+            catch (IOException ex)
+            {
+                Console.Error.WriteLine($"Error reading settings file: {ex.Message}");
+            }
+            catch (JsonException ex)
+            {
+                Console.Error.WriteLine($"Error deserializing settings file: {ex.Message}");
+            }
+
+            return MinecraftServerOptions.CreateDefault();
         }
 
         public static void Save(MinecraftServerOptions options)


### PR DESCRIPTION
## Summary
- Wrap settings file deserialization in try/catch for IO and JSON errors, logging and returning default options
- Add unit test validating fallback to defaults on malformed JSON

## Testing
- `dotnet test -p:EnableWindowsTargeting=true` *(fails: command not found)*
- `apt-get update` *(fails: repository ... is no longer signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68982fcf2b14832e8b5c634efdc98f4b