### PR TITLE
Add tests for configuration validation and process factory

### DIFF
--- a/MinecraftServer.Tests/ConfigurationValidatorServiceTests.cs
+++ b/MinecraftServer.Tests/ConfigurationValidatorServiceTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.IO;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using minecraft_windows_service_wrapper.Options;
+using minecraft_windows_service_wrapper.Services;
+
+namespace MinecraftServer.Tests
+{
+    public class ConfigurationValidatorServiceTests
+    {
+        private static MinecraftServerOptions CreateValidOptions(string tempDir)
+        {
+            var jarPath = Path.Combine(tempDir, "server.jar");
+            File.WriteAllText(jarPath, string.Empty);
+            return new MinecraftServerOptions
+            {
+                ServerDirectory = tempDir,
+                JarFileName = "server.jar",
+                MinecraftVersion = new Version(1, 16),
+                MaxMemoryMB = 4096,
+                MinMemoryMB = 1024,
+                GracefulShutdownTimeout = TimeSpan.FromMinutes(1)
+            };
+        }
+
+        [Fact]
+        public void ValidateConfiguration_NullOptions_ReturnsError()
+        {
+            var service = new ConfigurationValidatorService(Mock.Of<ILogger<ConfigurationValidatorService>>());
+            var result = service.ValidateConfiguration(null);
+            Assert.NotEqual(ValidationResult.Success, result);
+            Assert.Contains("Configuration options cannot be null", result.ErrorMessage);
+        }
+
+        [Fact]
+        public void ValidateConfiguration_InvalidMemorySettings_ReturnsError()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var options = CreateValidOptions(tempDir);
+                options.MinMemoryMB = 4096;
+                options.MaxMemoryMB = 1024;
+
+                var service = new ConfigurationValidatorService(Mock.Of<ILogger<ConfigurationValidatorService>>());
+                var result = service.ValidateConfiguration(options);
+
+                Assert.NotEqual(ValidationResult.Success, result);
+                Assert.Contains("Minimum memory", result.ErrorMessage);
+            }
+            finally
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+
+        [Fact]
+        public void ValidateConfiguration_ValidOptions_ReturnsSuccess()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var options = CreateValidOptions(tempDir);
+
+                var service = new ConfigurationValidatorService(Mock.Of<ILogger<ConfigurationValidatorService>>());
+                var result = service.ValidateConfiguration(options);
+
+                Assert.Equal(ValidationResult.Success, result);
+            }
+            finally
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+    }
+}

--- a/MinecraftServer.Tests/ProcessFactoryTests.cs
+++ b/MinecraftServer.Tests/ProcessFactoryTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -81,6 +82,29 @@ namespace MinecraftServer.Tests
                 File.Delete(jarPath);
                 Directory.Delete(tempDir);
             }
+        }
+
+        [Fact]
+        public void CreateJavaVersionDetectionProcess_SetsExpectedProperties()
+        {
+            // Arrange
+            var factory = new ProcessFactory(
+                Mock.Of<ILogger<ProcessFactory>>(),
+                Mock.Of<IJavaVersionService>(),
+                Mock.Of<IJavaVersionStrategyFactory>(),
+                Mock.Of<IMinecraftVersionStrategyFactory>());
+
+            // Act
+            var psi = factory.CreateJavaVersionDetectionProcess("java.exe");
+
+            // Assert
+            Assert.Equal("java.exe", psi.FileName);
+            Assert.Equal("-version", psi.Arguments);
+            Assert.True(psi.RedirectStandardInput);
+            Assert.True(psi.RedirectStandardOutput);
+            Assert.True(psi.RedirectStandardError);
+            Assert.False(psi.UseShellExecute);
+            Assert.Equal(ProcessWindowStyle.Hidden, psi.WindowStyle);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add tests covering configuration validator edge cases and success path
- verify ProcessFactory creates java version detection processes correctly

## Testing
- `dotnet test /p:EnableWindowsTargeting=true` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898d2b22f2c832ea703dc13959849b5